### PR TITLE
Make `find_available_port()` public

### DIFF
--- a/mocktail/src/lib.rs
+++ b/mocktail/src/lib.rs
@@ -13,6 +13,7 @@ pub use request::{Method, Request};
 mod response;
 pub use response::{Response, StatusCode};
 pub mod server;
+pub use server::find_available_port;
 pub mod prelude {
     pub use crate::{
         body::Body,

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -232,7 +232,7 @@ where
     Ok(())
 }
 
-fn find_available_port() -> Option<u16> {
+pub fn find_available_port() -> Option<u16> {
     let mut rng = rand::rng();
     loop {
         let port: u16 = rng.random_range(40000..60000);


### PR DESCRIPTION
The function `find_available_port()` might be useful for outside usage. Can we make it public again?