### PR TITLE
Implement StatusCode PartialEq for http::StatusCode

### DIFF
--- a/mocktail/src/response.rs
+++ b/mocktail/src/response.rs
@@ -210,6 +210,12 @@ impl PartialEq<StatusCode> for u16 {
     }
 }
 
+impl PartialEq<StatusCode> for http::StatusCode {
+    fn eq(&self, other: &StatusCode) -> bool {
+        *self == other.as_u16()
+    }
+}
+
 impl TryFrom<u16> for StatusCode {
     type Error = Error;
 


### PR DESCRIPTION
I'm using [reqwest](https://docs.rs/reqwest/latest/reqwest/) on another project and realized I couldn't compare the response directly to `mocktail::StatusCode`.

Sharing this PR in case it makes sense to have PartialEq implemented in mocktail::StatusCode. Just not sure if I added the test case to the appropriate file.