### PR TITLE
Refactor workaround to compare matchers while maintaining dyn-compatability

### DIFF
--- a/mocktail/src/body.rs
+++ b/mocktail/src/body.rs
@@ -93,6 +93,20 @@ impl PartialEq for Body {
     }
 }
 
+impl Eq for Body {}
+
+impl PartialOrd for Body {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Body {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.bufs.cmp(&other.bufs)
+    }
+}
+
 impl Stream for Body {
     type Item = Bytes;
 

--- a/mocktail/src/body/buf_list.rs
+++ b/mocktail/src/body/buf_list.rs
@@ -3,7 +3,7 @@ use std::collections::{vec_deque, VecDeque};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BufList {
     bufs: VecDeque<Bytes>,
 }

--- a/mocktail/src/headers.rs
+++ b/mocktail/src/headers.rs
@@ -1,6 +1,6 @@
 //! Headers
 /// Represents HTTP headers.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Headers(Vec<(HeaderName, HeaderValue)>);
 
 impl Headers {
@@ -147,7 +147,7 @@ impl From<Headers> for tonic::metadata::MetadataMap {
 }
 
 /// Represents a HTTP header name.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HeaderName(String);
 
 impl std::ops::Deref for HeaderName {
@@ -213,7 +213,7 @@ impl From<&http::HeaderName> for HeaderName {
 }
 
 /// Represents a HTTP header value.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HeaderValue(String);
 
 impl std::ops::Deref for HeaderValue {

--- a/mocktail/src/matchers.rs
+++ b/mocktail/src/matchers.rs
@@ -13,6 +13,7 @@ pub trait Matcher: std::fmt::Debug + Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
     /// Returns matcher as [`&dyn MatcherCompare`] to compare to another matcher.
     /// This is a workaround for dyn-compatability.
+    #[doc(hidden)]
     fn as_matcher_compare(&self) -> &dyn MatcherCompare;
 }
 

--- a/mocktail/src/mock_set.rs
+++ b/mocktail/src/mock_set.rs
@@ -105,3 +105,22 @@ impl FromIterator<Mock> for MockSet {
         Self(iter.into_iter().collect())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_builder() {
+        let mut mocks = MockSet::new();
+        mocks.mock(|when, then| {
+            when.post().path("/hello").text("hello");
+            then.text("hello!");
+        });
+        mocks.mock(|when, then| {
+            when.post().path("/hello").text("hey");
+            then.text("hello!");
+        });
+        assert_eq!(mocks.len(), 2);
+    }
+}

--- a/mocktail/src/request.rs
+++ b/mocktail/src/request.rs
@@ -79,7 +79,7 @@ impl Request {
 
 /// Represents a HTTP method.
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Method {
     #[default]
     GET,


### PR DESCRIPTION
This PR implements a workaround to enable properly comparing matchers.

Closes #21 