### PR TITLE
Add CI checks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,37 @@
+name: Run CI checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings" # Makes CI fail on compilation/clippy warnings
+
+jobs:
+  ci-checks:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: "Install fmt nightly"
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+    - uses: actions/checkout@v4
+    - name: Cache Rust dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+    - name: Build
+      run: cargo build
+    - name: Run formatter
+      run: cargo +nightly fmt --check --all
+    - name: Run linter
+      run: cargo clippy --no-deps --all-targets --all-features
+    - name: Run tests
+      run: cargo test

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -10,6 +10,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings" # Makes CI fail on compilation/clippy warnings
+  PROTOC_VERSION: "26.0"
+  
 
 jobs:
   ci-checks:
@@ -18,6 +20,13 @@ jobs:
     steps:
     - name: "Install fmt nightly"
       run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+    - name: "Install protoc"
+      run: |
+        echo "protoc version: ${PROTOC_VERSION}"
+        cd /tmp
+        curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+        sudo unzip protoc-*.zip -d /usr/local && rm protoc-*.zip
+        protoc --version
     - uses: actions/checkout@v4
     - name: Cache Rust dependencies
       uses: actions/cache@v4

--- a/mocktail/src/matchers.rs
+++ b/mocktail/src/matchers.rs
@@ -1,7 +1,8 @@
 //! Mock request matchers
+use std::{any::Any, borrow::Cow, cmp::Ordering};
+
 use super::{body::Body, headers::Headers, request::Request};
 use crate::request::Method;
-use std::{any::Any, borrow::Cow, cmp::Ordering};
 
 /// A matcher.
 pub trait Matcher: std::fmt::Debug + Send + Sync + 'static + AsMatcherEq {

--- a/mocktail/src/mock_builder/when.rs
+++ b/mocktail/src/mock_builder/when.rs
@@ -4,8 +4,11 @@ use std::{cell::Cell, rc::Rc};
 use bytes::Bytes;
 
 use crate::{
-    body::Body, headers::HeaderName, headers::HeaderValue, headers::Headers, matchers,
-    matchers::Matcher, request::Method,
+    body::Body,
+    headers::{HeaderName, HeaderValue, Headers},
+    matchers,
+    matchers::Matcher,
+    request::Method,
 };
 
 /// A request match conditions builder.

--- a/mocktail/src/response.rs
+++ b/mocktail/src/response.rs
@@ -176,7 +176,8 @@ impl StatusCode {
     pub const UPGRADE_REQUIRED: StatusCode = StatusCode(NonZeroU16::new(426).unwrap());
     pub const PRECONDITION_REQUIRED: StatusCode = StatusCode(NonZeroU16::new(428).unwrap());
     pub const TOO_MANY_REQUESTS: StatusCode = StatusCode(NonZeroU16::new(429).unwrap());
-    pub const REQUEST_HEADER_FIELDS_TOO_LARGE: StatusCode = StatusCode(NonZeroU16::new(431).unwrap());
+    pub const REQUEST_HEADER_FIELDS_TOO_LARGE: StatusCode =
+        StatusCode(NonZeroU16::new(431).unwrap());
     pub const UNAVAILABLE_FOR_LEGAL_REASONS: StatusCode = StatusCode(NonZeroU16::new(451).unwrap());
 
     pub const INTERNAL_SERVER_ERROR: StatusCode = StatusCode(NonZeroU16::new(500).unwrap());
@@ -189,7 +190,8 @@ impl StatusCode {
     pub const INSUFFICIENT_STORAGE: StatusCode = StatusCode(NonZeroU16::new(507).unwrap());
     pub const LOOP_DETECTED: StatusCode = StatusCode(NonZeroU16::new(508).unwrap());
     pub const NOT_EXTENDED: StatusCode = StatusCode(NonZeroU16::new(510).unwrap());
-    pub const NETWORK_AUTHENTICATION_REQUIRED: StatusCode = StatusCode(NonZeroU16::new(511).unwrap());
+    pub const NETWORK_AUTHENTICATION_REQUIRED: StatusCode =
+        StatusCode(NonZeroU16::new(511).unwrap());
 }
 
 impl Default for StatusCode {

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -1,4 +1,11 @@
 //! Mock server
+use std::{
+    cell::OnceCell,
+    net::{SocketAddr, TcpStream},
+    sync::{Arc, RwLock, RwLockWriteGuard},
+    time::Duration,
+};
+
 use http_body::Body;
 use hyper::{body::Incoming, service::Service};
 use hyper_util::{
@@ -6,12 +13,6 @@ use hyper_util::{
     server::conn,
 };
 use rand::Rng;
-use std::{
-    cell::OnceCell,
-    net::{SocketAddr, TcpStream},
-    sync::{Arc, RwLock, RwLockWriteGuard},
-    time::Duration,
-};
 use tokio::net::TcpListener;
 use tracing::{debug, error, info};
 use url::Url;


### PR DESCRIPTION
Addresses #26

Checks are the same as executing the following:

1. cargo build
2. cargo +nightly fmt --check --all
3. cargo clippy --no-deps --all-targets --all-features
4. cargo test

There is also a caching step to optimize builds. The cache will miss whenever `Cargo.toml` is updated.

Checks are triggered on every push to main or non-draft PRs.