### PR TITLE
Introducing `limit` of times a mock is available

### DIFF
--- a/book/src/concepts/mock-builder.md
+++ b/book/src/concepts/mock-builder.md
@@ -24,6 +24,8 @@ pub struct Mock {
     pub priority: u8, // defaults to 5 (more on this later)
     /// Match counter.
     pub match_count: AtomicUsize,
+    /// Limit on how many times this mock can be matched.
+    pub limit: Option<usize>,
 }
 ```
 

--- a/mocktail/src/mock.rs
+++ b/mocktail/src/mock.rs
@@ -86,8 +86,8 @@ impl Mock {
 
     /// Evaluates a request against match conditions.
     pub fn matches(&self, req: &Request) -> bool {
-        if let Some(times) = self.limit {
-            if self.match_count.load(Ordering::Relaxed) >= times {
+        if let Some(limit) = self.limit {
+            if self.match_count.load(Ordering::Relaxed) >= limit {
                 return false;
             }
         }

--- a/mocktail/src/mock.rs
+++ b/mocktail/src/mock.rs
@@ -153,7 +153,8 @@ mod tests {
         let mock = Mock::new(|when, then| {
             when.get();
             then.ok();
-        }).with_limit(2);
+        })
+        .with_limit(2);
         let request = Request::new(Method::GET, "http://localhost/".parse().unwrap());
         assert!(mock.matches(&request));
         assert!(mock.matches(&request));

--- a/mocktail/src/mock.rs
+++ b/mocktail/src/mock.rs
@@ -28,7 +28,7 @@ pub struct Mock {
     pub priority: u8,
     /// Match counter.
     pub match_count: AtomicUsize,
-    /// Limit the times the mock will work.
+    /// Limit on how many times this mock can be matched.
     pub limit: Option<usize>,
 }
 
@@ -59,8 +59,8 @@ impl Mock {
     }
 
     /// Sets the mock limit.
-    pub fn with_limit(mut self, times: usize) -> Self {
-        self.limit = Some(times);
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
         self
     }
 
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    fn test_times() {
+    fn test_limit() {
         let mock = Mock::new(|when, then| {
             when.get();
             then.ok();


### PR DESCRIPTION
As proposed in https://github.com/IBM/mocktail/issues/32 this introduces a little matcher helper to limit the amount of times a matcher successfully matches.

This enables testing of retries mechanisms on a client and hopefully help other cases too.

```rust
let mock = Mock::new(|when, then| {
    when.times(3, any());
    then.ok();
})
```