### PR TITLE
Add Mock id and match count, add MockServerState, rename mock_with_priority

### DIFF
--- a/book/src/concepts/mock-builder.md
+++ b/book/src/concepts/mock-builder.md
@@ -14,12 +14,16 @@ Together, they build a `Mock`, which consists of a set of request match conditio
 
 ```rust
 pub struct Mock {
+    /// Mock ID.
+    pub id: Uuid,
     /// A set of request match conditions.
-    pub matchers: Vec<Box<dyn Matcher>>,
+    pub matchers: Vec<Arc<dyn Matcher>>,
     /// A mock response.
     pub response: Response,
     /// Priority.
     pub priority: u8, // defaults to 5 (more on this later)
+    /// Match counter.
+    pub match_count: AtomicUsize,
 }
 ```
 

--- a/book/src/concepts/mock-set.md
+++ b/book/src/concepts/mock-set.md
@@ -4,4 +4,4 @@ A mock set is simply a set of mocks for a mock server. It is implemented as a ne
 
 It keeps mocks sorted by priority and ensures that there are no duplicates. It has shorthand `MockSet::mock()` and `MockSet::mock_with_priority()` methods to build and insert mocks directly into it. 
 
-The server calls it's `MockSet::match_to_response()` method to match incoming requests to mock responses.
+The server calls it's `MockSet::match_by_request()` method to match incoming requests to mock responses.

--- a/book/src/concepts/mock-set.md
+++ b/book/src/concepts/mock-set.md
@@ -2,6 +2,6 @@
 
 A mock set is simply a set of mocks for a mock server. It is implemented as a newtype wrapping `Vec<Mock>`. 
 
-It keeps mocks sorted by priority and ensures that there are no duplicates. It has shorthand `MockSet::mock()` and `MockSet::mock_with_priority()` methods to build and insert mocks directly into it. 
+It keeps mocks sorted by priority and ensures that there are no duplicates. It has shorthand `MockSet::mock()` and `MockSet::mock_with_options()` methods to build and insert mocks directly into it. 
 
 The server calls it's `MockSet::match_by_request()` method to match incoming requests to mock responses.

--- a/mocktail/Cargo.toml
+++ b/mocktail/Cargo.toml
@@ -34,3 +34,4 @@ tokio-stream = "0"
 tonic = "0.12"
 tracing = "0"
 url = "2"
+uuid = { version = "1.16.0", features = ["fast-rng", "v7"] }

--- a/mocktail/src/mock.rs
+++ b/mocktail/src/mock.rs
@@ -1,6 +1,8 @@
 //! Mock
 use std::sync::Arc;
 
+use uuid::Uuid;
+
 use crate::{
     matchers::Matcher,
     mock_builder::{Then, When},
@@ -13,6 +15,8 @@ const DEFAULT_PRIORITY: u8 = 5;
 /// A mock.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Mock {
+    /// Mock ID.
+    pub id: Uuid,
     /// A set of request match conditions.
     pub matchers: Vec<Arc<dyn Matcher>>,
     /// A mock response.
@@ -27,10 +31,12 @@ impl Mock {
     where
         F: FnOnce(When, Then),
     {
+        let id = Uuid::now_v7();
         let when = When::new();
         let then = Then::new();
         f(when.clone(), then.clone());
         Self {
+            id,
             matchers: when.into_inner(),
             response: then.into_inner(),
             priority: DEFAULT_PRIORITY,
@@ -41,6 +47,11 @@ impl Mock {
     pub fn with_priority(mut self, priority: u8) -> Self {
         self.priority = priority;
         self
+    }
+
+    /// Returns the mock ID.
+    pub fn id(&self) -> &Uuid {
+        &self.id
     }
 
     /// Returns the mock response.

--- a/mocktail/src/mock.rs
+++ b/mocktail/src/mock.rs
@@ -1,4 +1,6 @@
 //! Mock
+use std::sync::Arc;
+
 use crate::{
     matchers::Matcher,
     mock_builder::{Then, When},
@@ -9,10 +11,10 @@ use crate::{
 const DEFAULT_PRIORITY: u8 = 5;
 
 /// A mock.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Mock {
     /// A set of request match conditions.
-    pub matchers: Vec<Box<dyn Matcher>>,
+    pub matchers: Vec<Arc<dyn Matcher>>,
     /// A mock response.
     pub response: Response,
     /// Priority.
@@ -54,15 +56,5 @@ impl Mock {
     /// Evaluates a request against match conditions.
     pub fn matches(&self, req: &Request) -> bool {
         self.matchers.iter().all(|matcher| matcher.matches(req))
-    }
-}
-
-impl From<(Vec<Box<dyn Matcher>>, Response)> for Mock {
-    fn from(value: (Vec<Box<dyn Matcher>>, Response)) -> Self {
-        Self {
-            matchers: value.0,
-            response: value.1,
-            priority: DEFAULT_PRIORITY,
-        }
     }
 }

--- a/mocktail/src/mock_builder/when.rs
+++ b/mocktail/src/mock_builder/when.rs
@@ -1,5 +1,5 @@
 //! When
-use std::{cell::Cell, rc::Rc};
+use std::{cell::Cell, rc::Rc, sync::Arc};
 
 use bytes::Bytes;
 
@@ -13,7 +13,7 @@ use crate::{
 
 /// A request match conditions builder.
 #[derive(Default, Clone)]
-pub struct When(Rc<Cell<Vec<Box<dyn Matcher>>>>);
+pub struct When(Rc<Cell<Vec<Arc<dyn Matcher>>>>);
 
 impl When {
     pub fn new() -> Self {
@@ -21,7 +21,7 @@ impl When {
     }
 
     /// Sorts, deduplicates, and returns the inner set of matchers.
-    pub fn into_inner(self) -> Vec<Box<dyn Matcher>> {
+    pub fn into_inner(self) -> Vec<Arc<dyn Matcher>> {
         let mut m = self.0.take();
         m.sort_unstable();
         m.dedup();
@@ -31,7 +31,7 @@ impl When {
     /// Pushes a matcher to the set of matchers.
     fn push(&self, matcher: impl Matcher) {
         let mut m = self.0.take();
-        m.push(Box::new(matcher));
+        m.push(Arc::new(matcher));
         self.0.set(m);
     }
 

--- a/mocktail/src/mock_set.rs
+++ b/mocktail/src/mock_set.rs
@@ -38,7 +38,7 @@ impl MockSet {
         self.0.contains(mock)
     }
 
-    /// Builds and inserts a mock.
+    /// Builds and inserts a mock with default options.
     pub fn mock<F>(&mut self, f: F)
     where
         F: FnOnce(When, Then),
@@ -47,8 +47,8 @@ impl MockSet {
         self.insert(mock);
     }
 
-    /// Builds and inserts a mock with explicit priority.
-    pub fn mock_with_priority<F>(&mut self, priority: u8, f: F)
+    /// Builds and inserts a mock with options.
+    pub fn mock_with_options<F>(&mut self, priority: u8, f: F)
     where
         F: FnOnce(When, Then),
     {

--- a/mocktail/src/mock_set.rs
+++ b/mocktail/src/mock_set.rs
@@ -3,7 +3,6 @@ use crate::{
     mock::Mock,
     mock_builder::{Then, When},
     request::Request,
-    response::Response,
 };
 
 /// A set of mocks.
@@ -80,13 +79,9 @@ impl MockSet {
         self.0.iter()
     }
 
-    /// Matches a request to a mock response.
-    pub fn match_to_response(&self, request: &Request) -> Option<Response> {
-        self.0
-            .iter()
-            .find(|&mock| mock.matches(request))
-            .map(|mock| mock.response())
-            .cloned()
+    /// Matches a request to a mock.
+    pub fn match_by_request(&self, request: &Request) -> Option<Mock> {
+        self.0.iter().find(|&mock| mock.matches(request)).cloned()
     }
 }
 

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -2,7 +2,7 @@
 use std::{
     cell::OnceCell,
     net::{SocketAddr, TcpStream},
-    sync::{Arc, RwLock, RwLockWriteGuard},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
     time::Duration,
 };
 
@@ -31,7 +31,7 @@ pub struct MockServer {
     kind: ServerKind,
     addr: OnceCell<SocketAddr>,
     base_url: OnceCell<Url>,
-    mocks: Arc<RwLock<MockSet>>,
+    state: Arc<MockServerState>,
 }
 
 impl MockServer {
@@ -42,7 +42,7 @@ impl MockServer {
             kind: ServerKind::Http,
             addr: OnceCell::new(),
             base_url: OnceCell::new(),
-            mocks: Arc::new(RwLock::new(MockSet::default())),
+            state: Arc::new(MockServerState::default()),
         }
     }
 
@@ -53,8 +53,8 @@ impl MockServer {
     }
 
     /// Sets the server mocks.
-    pub fn with_mocks(mut self, mocks: MockSet) -> Self {
-        self.mocks = Arc::new(RwLock::new(mocks));
+    pub fn with_mocks(self, mocks: MockSet) -> Self {
+        *self.state.mocks.write().unwrap() = mocks;
         self
     }
 
@@ -69,11 +69,11 @@ impl MockServer {
         let listener = TcpListener::bind(&addr).await?;
         match self.kind {
             ServerKind::Http => {
-                let service = HttpMockService::new(self.mocks.clone());
+                let service = HttpMockService::new(self.state.clone());
                 tokio::spawn(run_server(listener, self.kind, service));
             }
             ServerKind::Grpc => {
-                let service = GrpcMockService::new(self.mocks.clone());
+                let service = GrpcMockService::new(self.state.clone());
                 tokio::spawn(run_server(listener, self.kind, service));
             }
         };
@@ -125,7 +125,7 @@ impl MockServer {
     }
 
     pub fn mocks(&self) -> RwLockWriteGuard<'_, MockSet> {
-        self.mocks.write().unwrap()
+        self.state.mocks.write().unwrap()
     }
 
     /// Builds and inserts a mock.
@@ -134,7 +134,7 @@ impl MockServer {
         F: FnOnce(When, Then),
     {
         let mock = Mock::new(f);
-        self.mocks().insert(mock);
+        self.state.mocks.write().unwrap().insert(mock);
     }
 
     /// Builds and inserts a mock with explicit priority.
@@ -143,7 +143,25 @@ impl MockServer {
         F: FnOnce(When, Then),
     {
         let mock = Mock::new(f).with_priority(priority);
-        self.mocks().insert(mock);
+        self.state.mocks.write().unwrap().insert(mock);
+    }
+}
+
+/// Mock server state.
+#[derive(Debug, Default)]
+pub struct MockServerState {
+    pub mocks: RwLock<MockSet>,
+}
+
+impl MockServerState {
+    pub fn new(mocks: MockSet) -> Self {
+        Self {
+            mocks: RwLock::new(mocks),
+        }
+    }
+
+    pub fn mocks(&self) -> RwLockReadGuard<'_, MockSet> {
+        self.mocks.read().unwrap()
     }
 }
 

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -128,7 +128,7 @@ impl MockServer {
         self.state.mocks.write().unwrap()
     }
 
-    /// Builds and inserts a mock.
+    /// Builds and inserts a mock with default options.
     pub fn mock<F>(&mut self, f: F)
     where
         F: FnOnce(When, Then),
@@ -137,8 +137,8 @@ impl MockServer {
         self.state.mocks.write().unwrap().insert(mock);
     }
 
-    /// Builds and inserts a mock with explicit priority.
-    pub fn mock_with_priority<F>(&mut self, priority: u8, f: F)
+    /// Builds and inserts a mock with options.
+    pub fn mock_with_options<F>(&mut self, priority: u8, f: F)
     where
         F: FnOnce(When, Then),
     {

--- a/mocktail/src/service/grpc.rs
+++ b/mocktail/src/service/grpc.rs
@@ -1,8 +1,5 @@
 //! Mock gRPC service
-use std::{
-    convert::Infallible,
-    sync::{Arc, RwLock},
-};
+use std::{convert::Infallible, sync::Arc};
 
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, StreamExt};
@@ -15,17 +12,17 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::body::BoxBody;
 use tracing::debug;
 
-use crate::{mock_set::MockSet, request::Request};
+use crate::{request::Request, server::MockServerState};
 
 /// Mock gRPC service.
 #[derive(Debug, Clone)]
 pub struct GrpcMockService {
-    pub mocks: Arc<RwLock<MockSet>>,
+    state: Arc<MockServerState>,
 }
 
 impl GrpcMockService {
-    pub fn new(mocks: Arc<RwLock<MockSet>>) -> Self {
-        Self { mocks }
+    pub fn new(state: Arc<MockServerState>) -> Self {
+        Self { state }
     }
 }
 
@@ -35,7 +32,7 @@ impl Service<http::Request<Incoming>> for GrpcMockService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn call(&self, req: http::Request<Incoming>) -> Self::Future {
-        let mocks = self.mocks.clone();
+        let state = self.state.clone();
         let fut = async move {
             debug!(?req, "handling request");
 
@@ -85,7 +82,7 @@ impl Service<http::Request<Incoming>> for GrpcMockService {
 
                     // Match request to mock
                     request = request.with_body(buf.clone().freeze());
-                    let mock = mocks.read().unwrap().match_by_request(&request);
+                    let mock = state.mocks().match_by_request(&request);
                     if let Some(mock) = mock {
                         matched = true;
                         debug!("mock found, sending response");

--- a/mocktail/src/service/grpc.rs
+++ b/mocktail/src/service/grpc.rs
@@ -83,13 +83,13 @@ impl Service<http::Request<Incoming>> for GrpcMockService {
                     // Add chunk to body buffer
                     buf.extend(chunk);
 
-                    // Match request to mock response
+                    // Match request to mock
                     request = request.with_body(buf.clone().freeze());
-                    let response = mocks.read().unwrap().match_to_response(&request);
-
-                    if let Some(mut response) = response {
+                    let mock = mocks.read().unwrap().match_by_request(&request);
+                    if let Some(mock) = mock {
                         matched = true;
                         debug!("mock found, sending response");
+                        let mut response = mock.response;
                         // Send data frames
                         if !response.body().is_empty() {
                             while let Some(chunk) = response.body.next().await {


### PR DESCRIPTION
Mock updates:
- Use `Arc` instead of `Box` for matcher trait objects to make `Mock` cloneable
- Implement `Clone`
- Add unique ID `mock.id` and associated method `Mock::id()` for future use
- Add match counter `mock.match_count` and associated methods `Mock::match_count()` and `Mock::reset()`

MockSet updates:
- Rename `MockSet::mock_with_priority()` to `MockSet::mock_with_options()` (and the same methods on `MockServer`) as we may add additional configurable options.
  - `mock()` uses defaults and `mock_with_options()` enables setting options explicitly
- Replace `MockSet::match_to_response()` with `MockSet::match_by_request()`, returning the `Mock` rather than just the mock `Response`. This is so that additional mock fields such as `mock.id` and `mock.match_count` can be used by the service.

Other updates:
- Add `MockServerState`, add `MockSet` to it. This is so we can add additional shared server state.