### PR TITLE
Add limit to mock_with_options

### DIFF
--- a/mocktail/src/mock_set.rs
+++ b/mocktail/src/mock_set.rs
@@ -48,11 +48,14 @@ impl MockSet {
     }
 
     /// Builds and inserts a mock with options.
-    pub fn mock_with_options<F>(&mut self, priority: u8, f: F)
+    pub fn mock_with_options<F>(&mut self, priority: u8, limit: Option<usize>, f: F)
     where
         F: FnOnce(When, Then),
     {
-        let mock = Mock::new(f).with_priority(priority);
+        let mut mock = Mock::new(f).with_priority(priority);
+        if let Some(limit) = limit {
+            mock = mock.with_limit(limit);
+        }
         self.insert(mock);
     }
 

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -138,11 +138,14 @@ impl MockServer {
     }
 
     /// Builds and inserts a mock with options.
-    pub fn mock_with_options<F>(&mut self, priority: u8, f: F)
+    pub fn mock_with_options<F>(&mut self, priority: u8, limit: Option<usize>, f: F)
     where
         F: FnOnce(When, Then),
     {
-        let mock = Mock::new(f).with_priority(priority);
+        let mut mock = Mock::new(f).with_priority(priority);
+        if let Some(limit) = limit {
+            mock = mock.with_limit(limit);
+        }
         self.state.mocks.write().unwrap().insert(mock);
     }
 }


### PR DESCRIPTION
@ferranjr I just realized we forgot to add `limit` to `mock_with_options`, so adding here.