### PR TITLE
Add find_port retry logic

### DIFF
--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -242,6 +242,12 @@ pub struct MockServerConfig {
     bind_max_retries: usize,
 }
 
+impl MockServerConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 impl Default for MockServerConfig {
     fn default() -> Self {
         Self {

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -246,8 +246,8 @@ impl Default for MockServerConfig {
     fn default() -> Self {
         Self {
             listen_addr: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            port_range_start: 40000,
-            port_range_end: 60000,
+            port_range_start: 10000,
+            port_range_end: 30000,
             bind_max_retries: 3,
         }
     }


### PR DESCRIPTION
This addresses #38.

@declark1 I've made things a little bit different than you suggested, but let me know your thoughts. In a nutshell:

1. I'm massing `MockServerConfig` as a single parameter to `find_available_port()` instead of three parameters.
2. Implemented the retry loop in `find_available_port()` instead of `start()`

I tried returning an [IOError](https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.AddrNotAvailable) instead of just keeping the `unwrap()` but I couldn't figure out how to use thiserror.

Also, I've updated the default ports range from 10000 to 30000 based on your [recent comment](https://github.com/IBM/mocktail/issues/38#issuecomment-2761267307).