### PR TITLE
Add MockServer::new_http() and MockServer::new_grpc()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mocktail is a **minimal** crate for mocking HTTP and gRPC servers in Rust, with 
 1. Add `mocktail` to `Cargo.toml` as a development dependency:
     ```toml
     [dev-dependencies]
-    mocktail = "0.2.5-alpha"
+    mocktail = "0.2.6-alpha"
     ```
 
 2. Basic usage example:
@@ -46,7 +46,7 @@ mocktail is a **minimal** crate for mocking HTTP and gRPC servers in Rust, with 
         });
 
         // Create and start a mock server
-        let mut server = MockServer::new("example").with_mocks(mocks);
+        let mut server = MockServer::new_http("example").with_mocks(mocks);
         server.start().await?;
 
         // Create a client

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mocktail is a **minimal** crate for mocking HTTP and gRPC servers in Rust, with 
 1. Add `mocktail` to `Cargo.toml` as a development dependency:
     ```toml
     [dev-dependencies]
-    mocktail = "0.2.6-alpha"
+    mocktail = "0.3.0"
     ```
 
 2. Basic usage example:

--- a/book/src/concepts/mock-server.md
+++ b/book/src/concepts/mock-server.md
@@ -2,11 +2,14 @@
 
 The mock server is a simple, lightweight HTTP server designed for serving mocks. It has 2 service implementations: `HttpMockService` and `GrpcMockService`. The server supports HTTP/1 and HTTP/2.
 
+## HTTP
+Use `MockServer::new_http()` to create a HTTP mock server.
+
 ## gRPC
-By default, the `HttpMockService` is used for serving regular HTTP mocks. For gRPC, set the `grpc()` option on the server to enable the `GrpcMockService`. You can use tonic to connect to the gRPC service.
+Use `MockServer::new_grpc()` to create a gRPC mock server. You can use tonic to connect to the gRPC service, e.g.
 
 ```rust
-    let server = MockServer::new().grpc();
+    let server = MockServer::new_grpc("name");
     let url = format!("http://0.0.0.0:{}", server.port().unwrap());
     let channel = tonic::Channel::from_shared(url)?
         .connect()

--- a/book/src/defining-mocks.md
+++ b/book/src/defining-mocks.md
@@ -14,14 +14,14 @@ You can define your mocks first, then create a mock server with your mock set:
     // Alternatively, Mock::new() and mocks.insert(mock)
 
     // Create mock server with the mock set
-    let mut server = MockServer::new("example").with_mocks(mocks);
+    let mut server = MockServer::new_http("example").with_mocks(mocks);
     server.run().await?;
 ```
 
 Or, you can create a mock server with a default empty mock set and register mocks directly to the server:
 ```rust
     // Create mock server
-    let mut server = MockServer::new("example");
+    let mut server = MockServer::new_http("example");
     server.run().await?;
 
     // Build and insert a mock to the server's mock set

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -3,7 +3,7 @@
 1. Add `mocktail` to `Cargo.toml` as a development dependency:
     ```toml
     [dev-dependencies]
-    mocktail = "0.2.6-alpha"
+    mocktail = "0.3.0"
     ```
 
 2. Basic usage example:

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -3,7 +3,7 @@
 1. Add `mocktail` to `Cargo.toml` as a development dependency:
     ```toml
     [dev-dependencies]
-    mocktail = "0.2.5-alpha"
+    mocktail = "0.2.6-alpha"
     ```
 
 2. Basic usage example:
@@ -24,7 +24,7 @@
         });
 
         // Create and start a mock server
-        let mut server = MockServer::new("example").with_mocks(mocks);
+        let mut server = MockServer::new_http("example").with_mocks(mocks);
         server.start().await?;
 
         // Create a client

--- a/mocktail-tests/tests/examples/grpc_streaming.rs
+++ b/mocktail-tests/tests/examples/grpc_streaming.rs
@@ -26,7 +26,7 @@ async fn test_client_streaming() -> Result<(), Error> {
         });
     });
 
-    let server = MockServer::new("example.Hello").grpc().with_mocks(mocks);
+    let server = MockServer::new_grpc("example.Hello").with_mocks(mocks);
     server.start().await?;
 
     let channel = Channel::from_shared(format!("http://0.0.0.0:{}", server.port().unwrap()))?
@@ -68,7 +68,7 @@ async fn test_server_streaming() -> Result<(), Error> {
         ]);
     });
 
-    let server = MockServer::new("example.Hello").grpc().with_mocks(mocks);
+    let server = MockServer::new_grpc("example.Hello").with_mocks(mocks);
     server.start().await?;
 
     let channel = Channel::from_shared(format!("http://0.0.0.0:{}", server.port().unwrap()))?

--- a/mocktail-tests/tests/examples/grpc_unary.rs
+++ b/mocktail-tests/tests/examples/grpc_unary.rs
@@ -15,7 +15,7 @@ async fn test_unary() -> Result<(), Error> {
         });
     });
 
-    let server = MockServer::new("example.Hello").grpc().with_mocks(mocks);
+    let server = MockServer::new_grpc("example.Hello").with_mocks(mocks);
     server.start().await?;
 
     let channel = Channel::from_shared(format!("http://0.0.0.0:{}", server.port().unwrap()))?
@@ -48,7 +48,7 @@ async fn test_unary_errors() -> Result<(), anyhow::Error> {
         then.internal_server_error().message("unexpected error");
     });
 
-    let server = MockServer::new("example.Hello").grpc().with_mocks(mocks);
+    let server = MockServer::new_grpc("example.Hello").with_mocks(mocks);
     server.start().await?;
 
     let channel = Channel::from_shared(format!("http://0.0.0.0:{}", server.port().unwrap()))?

--- a/mocktail-tests/tests/examples/headers.rs
+++ b/mocktail-tests/tests/examples/headers.rs
@@ -26,7 +26,7 @@ async fn test_headers() -> Result<(), Error> {
         then.text("you had the header!");
     });
 
-    let server = MockServer::new("hello").with_mocks(mocks);
+    let server = MockServer::new_http("hello").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;

--- a/mocktail-tests/tests/examples/http_streaming.rs
+++ b/mocktail-tests/tests/examples/http_streaming.rs
@@ -36,7 +36,7 @@ async fn test_json_lines_stream() -> Result<(), Error> {
         ]);
     });
 
-    let server = MockServer::new("hello").with_mocks(mocks);
+    let server = MockServer::new_http("hello").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;
@@ -76,7 +76,7 @@ async fn test_bytes_stream() -> Result<(), Error> {
         then.bytes_stream(["hello dan!", "hello mateus!"]);
     });
 
-    let server = MockServer::new("hello").with_mocks(mocks);
+    let server = MockServer::new_http("hello").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;
@@ -120,7 +120,7 @@ async fn test_sse_stream() -> Result<(), Error> {
         ]);
     });
 
-    let server = MockServer::new("sse").with_mocks(mocks);
+    let server = MockServer::new_http("sse").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;

--- a/mocktail-tests/tests/examples/http_unary.rs
+++ b/mocktail-tests/tests/examples/http_unary.rs
@@ -30,7 +30,7 @@ async fn test_unary() -> Result<(), Error> {
         then.text("hello!");
     });
 
-    let server = MockServer::new("hello").with_mocks(mocks);
+    let server = MockServer::new_http("hello").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;
@@ -71,7 +71,7 @@ async fn test_unary_errors() -> Result<(), Error> {
         then.bad_request();
     });
 
-    let server = MockServer::new("hello").with_mocks(mocks);
+    let server = MockServer::new_http("hello").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;
@@ -129,7 +129,7 @@ async fn test_any() -> Result<(), Error> {
         then.text("yo!");
     });
 
-    let server = MockServer::new("any").with_mocks(mocks);
+    let server = MockServer::new_http("any").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;
@@ -158,7 +158,7 @@ async fn test_unary_headers() -> Result<(), Error> {
         then.text("yo!");
     });
 
-    let server = MockServer::new("any").with_mocks(mocks);
+    let server = MockServer::new_http("any").with_mocks(mocks);
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;

--- a/mocktail-tests/tests/misc/validation.rs
+++ b/mocktail-tests/tests/misc/validation.rs
@@ -4,7 +4,7 @@ use test_log::test;
 
 #[test(tokio::test)]
 async fn test_grpc_service() -> Result<(), Error> {
-    let server = MockServer::new("test").grpc();
+    let server = MockServer::new_grpc("test");
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;
@@ -30,7 +30,7 @@ async fn test_grpc_service() -> Result<(), Error> {
 
 #[test(tokio::test)]
 async fn test_http_service() -> Result<(), Error> {
-    let server = MockServer::new("test");
+    let server = MockServer::new_http("test");
     server.start().await?;
 
     let client = reqwest::Client::builder().http2_prior_knowledge().build()?;

--- a/mocktail/Cargo.toml
+++ b/mocktail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocktail"
-version = "0.2.6-alpha"
+version = "0.3.0"
 edition = "2021"
 authors = ["Dan Clark"]
 description = "HTTP & gRPC server mocking for Rust"

--- a/mocktail/Cargo.toml
+++ b/mocktail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocktail"
-version = "0.2.5-alpha"
+version = "0.2.6-alpha"
 edition = "2021"
 authors = ["Dan Clark"]
 description = "HTTP & gRPC server mocking for Rust"

--- a/mocktail/src/request.rs
+++ b/mocktail/src/request.rs
@@ -113,7 +113,7 @@ impl std::str::FromStr for Method {
             "OPTIONS" => Ok(Method::OPTIONS),
             "TRACE" => Ok(Method::TRACE),
             "PATCH" => Ok(Method::PATCH),
-            _ => Err(format!("Invalid HTTP method {}", value)),
+            _ => Err(format!("Invalid HTTP method {value}")),
         }
     }
 }
@@ -132,7 +132,7 @@ impl TryFrom<&str> for Method {
             "OPTIONS" => Ok(Self::OPTIONS),
             "TRACE" => Ok(Self::TRACE),
             "PATCH" => Ok(Self::PATCH),
-            _ => Err(format!("Invalid HTTP method {}", value)),
+            _ => Err(format!("Invalid HTTP method {value}")),
         }
     }
 }

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -73,7 +73,7 @@ impl MockServer {
     }
 
     /// Sets the server type to gRPC.
-    #[deprecated(since = "0.2.6-alpha", note = "please use `new_grpc` instead")]
+    #[deprecated(since = "0.3.0", note = "please use `new_grpc` instead")]
     pub fn grpc(mut self) -> Self {
         self.kind = ServerKind::Grpc;
         self

--- a/mocktail/src/server.rs
+++ b/mocktail/src/server.rs
@@ -36,7 +36,7 @@ pub struct MockServer {
 }
 
 impl MockServer {
-    /// Creates a new [`MockServer`].
+    /// Creates a new HTTP [`MockServer`].
     pub fn new(name: &'static str) -> Self {
         Self {
             name,
@@ -48,7 +48,32 @@ impl MockServer {
         }
     }
 
+    /// Creates a new HTTP [`MockServer`].
+    pub fn new_http(name: &'static str) -> Self {
+        Self {
+            name,
+            kind: ServerKind::Http,
+            addr: OnceLock::new(),
+            base_url: OnceLock::new(),
+            state: Arc::new(MockServerState::default()),
+            config: MockServerConfig::default(),
+        }
+    }
+
+    /// Creates a new gRPC [`MockServer`].
+    pub fn new_grpc(name: &'static str) -> Self {
+        Self {
+            name,
+            kind: ServerKind::Grpc,
+            addr: OnceLock::new(),
+            base_url: OnceLock::new(),
+            state: Arc::new(MockServerState::default()),
+            config: MockServerConfig::default(),
+        }
+    }
+
     /// Sets the server type to gRPC.
+    #[deprecated(since = "0.2.6-alpha", note = "please use `new_grpc` instead")]
     pub fn grpc(mut self) -> Self {
         self.kind = ServerKind::Grpc;
         self


### PR DESCRIPTION
This PR adds new constructor methods to `MockServer` to specify the server type more explicitly: `MockServer::new_http()` and `MockServer::new_grpc()`. 

Previously, the `grpc()` builder method was used to set the server type to gRPC, e.g. `MockServer::new().grpc()`, which is a bit weird in this case and easy to forget.

`MockServer::new()` is unchanged and still creates a HTTP mock server. The `grpc()` builder method has been deprecated in favor of `MockServer::new_grpc()`.

This also prepares version `0.3.0` and drops the "alpha" suffix from the version. `0.*` will be considered alpha.

Closes #52 