### PR TITLE
Update mocktail version to 0.3.1 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mocktail is a **minimal** crate for mocking HTTP and gRPC servers in Rust, with 
 1. Add `mocktail` to `Cargo.toml` as a development dependency:
     ```toml
     [dev-dependencies]
-    mocktail = "0.3.0"
+    mocktail = "0.3.1"
     ```
 
 2. Basic usage example:

--- a/mocktail/Cargo.toml
+++ b/mocktail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocktail"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Dan Clark"]
 description = "HTTP & gRPC server mocking for Rust"


### PR DESCRIPTION
### Changes

`0.3.1` release with dependency update